### PR TITLE
Fix sandbox.json instructions for containerd 1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,10 @@ $ cat > sandbox.json << EOL
         "name": "nginx-sandbox",
         "namespace": "default",
         "attempt": 1,
-        "uid": "hdishd83djaidwnduwk28bcsb",
-        "annotations": {
-          "io.kubernetes.cri.untrusted-workload": "true"
-        }
+        "uid": "hdishd83djaidwnduwk28bcsb"
+    },
+    "annotations": {
+      "io.kubernetes.cri.untrusted-workload": "true"
     },
     "linux": {
     },


### PR DESCRIPTION
Annotations aren't part of the PodSandboxMetadata but rather part of the
PodSandboxConfig object. crictl's parsing logic seems to ignore
extraneous fields so it silently fails to create pods using the
untrusted workload runtime.

See: https://github.com/kubernetes-sigs/cri-tools/blob/v1.13.0/vendor/k8s.io/kubernetes/pkg/kubelet/apis/cri/runtime/v1alpha2/api.pb.go#L775

Related: #4 