### PR TITLE
Update to containerd 1.2.2

### DIFF
--- a/pkg/v1/proc/exec.go
+++ b/pkg/v1/proc/exec.go
@@ -42,7 +42,7 @@ import (
 type execProcess struct {
 	wg sync.WaitGroup
 
-	proc.State
+	execState execState
 
 	mu          sync.Mutex
 	id          string
@@ -88,11 +88,25 @@ func (e *execProcess) ExitedAt() time.Time {
 	return e.exited
 }
 
+func (e *execProcess) SetExited(status int) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.execState.SetExited(status)
+}
+
 func (e *execProcess) setExited(status int) {
 	e.status = status
 	e.exited = time.Now()
 	e.parent.Platform.ShutdownConsole(context.Background(), e.console)
 	close(e.waitBlock)
+}
+
+func (e *execProcess) Delete(ctx context.Context) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	return e.execState.Delete(ctx)
 }
 
 func (e *execProcess) delete(ctx context.Context) error {
@@ -112,11 +126,25 @@ func (e *execProcess) delete(ctx context.Context) error {
 	return nil
 }
 
+func (e *execProcess) Resize(ws console.WinSize) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	return e.execState.Resize(ws)
+}
+
 func (e *execProcess) resize(ws console.WinSize) error {
 	if e.console == nil {
 		return nil
 	}
 	return e.console.Resize(ws)
+}
+
+func (e *execProcess) Kill(ctx context.Context, sig uint32, _ bool) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	return e.execState.Kill(ctx, sig, false)
 }
 
 func (e *execProcess) kill(ctx context.Context, sig uint32, _ bool) error {
@@ -139,6 +167,13 @@ func (e *execProcess) Stdin() io.Closer {
 
 func (e *execProcess) Stdio() proc.Stdio {
 	return e.stdio
+}
+
+func (e *execProcess) Start(ctx context.Context) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	return e.execState.Start(ctx)
 }
 
 func (e *execProcess) start(ctx context.Context) (err error) {

--- a/pkg/v1/proc/exec_state.go
+++ b/pkg/v1/proc/exec_state.go
@@ -24,6 +24,14 @@ import (
 	"github.com/pkg/errors"
 )
 
+type execState interface {
+	Resize(console.WinSize) error
+	Start(context.Context) error
+	Delete(context.Context) error
+	Kill(context.Context, uint32, bool) error
+	SetExited(int)
+}
+
 type execCreatedState struct {
 	p *execProcess
 }
@@ -31,11 +39,11 @@ type execCreatedState struct {
 func (s *execCreatedState) transition(name string) error {
 	switch name {
 	case "running":
-		s.p.State = &execRunningState{p: s.p}
+		s.p.execState = &execRunningState{p: s.p}
 	case "stopped":
-		s.p.State = &execStoppedState{p: s.p}
+		s.p.execState = &execStoppedState{p: s.p}
 	case "deleted":
-		s.p.State = &deletedState{}
+		s.p.execState = &deletedState{}
 	default:
 		return errors.Errorf("invalid state transition %q to %q", stateName(s), name)
 	}
@@ -43,15 +51,10 @@ func (s *execCreatedState) transition(name string) error {
 }
 
 func (s *execCreatedState) Resize(ws console.WinSize) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	return s.p.resize(ws)
 }
 
 func (s *execCreatedState) Start(ctx context.Context) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
 	if err := s.p.start(ctx); err != nil {
 		return err
 	}
@@ -62,22 +65,14 @@ func (s *execCreatedState) Delete(ctx context.Context) error {
 	if err := s.p.delete(ctx); err != nil {
 		return err
 	}
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
 	return s.transition("deleted")
 }
 
 func (s *execCreatedState) Kill(ctx context.Context, sig uint32, all bool) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	return s.p.kill(ctx, sig, all)
 }
 
 func (s *execCreatedState) SetExited(status int) {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	s.p.setExited(status)
 
 	if err := s.transition("stopped"); err != nil {
@@ -92,7 +87,7 @@ type execRunningState struct {
 func (s *execRunningState) transition(name string) error {
 	switch name {
 	case "stopped":
-		s.p.State = &execStoppedState{p: s.p}
+		s.p.execState = &execStoppedState{p: s.p}
 	default:
 		return errors.Errorf("invalid state transition %q to %q", stateName(s), name)
 	}
@@ -100,37 +95,22 @@ func (s *execRunningState) transition(name string) error {
 }
 
 func (s *execRunningState) Resize(ws console.WinSize) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	return s.p.resize(ws)
 }
 
 func (s *execRunningState) Start(ctx context.Context) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	return errors.Errorf("cannot start a running process")
 }
 
 func (s *execRunningState) Delete(ctx context.Context) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	return errors.Errorf("cannot delete a running process")
 }
 
 func (s *execRunningState) Kill(ctx context.Context, sig uint32, all bool) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	return s.p.kill(ctx, sig, all)
 }
 
 func (s *execRunningState) SetExited(status int) {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	s.p.setExited(status)
 
 	if err := s.transition("stopped"); err != nil {
@@ -145,7 +125,7 @@ type execStoppedState struct {
 func (s *execStoppedState) transition(name string) error {
 	switch name {
 	case "deleted":
-		s.p.State = &deletedState{}
+		s.p.execState = &deletedState{}
 	default:
 		return errors.Errorf("invalid state transition %q to %q", stateName(s), name)
 	}
@@ -153,16 +133,10 @@ func (s *execStoppedState) transition(name string) error {
 }
 
 func (s *execStoppedState) Resize(ws console.WinSize) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	return errors.Errorf("cannot resize a stopped container")
 }
 
 func (s *execStoppedState) Start(ctx context.Context) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	return errors.Errorf("cannot start a stopped process")
 }
 
@@ -170,15 +144,10 @@ func (s *execStoppedState) Delete(ctx context.Context) error {
 	if err := s.p.delete(ctx); err != nil {
 		return err
 	}
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
 	return s.transition("deleted")
 }
 
 func (s *execStoppedState) Kill(ctx context.Context, sig uint32, all bool) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	return s.p.kill(ctx, sig, all)
 }
 

--- a/vendor.conf
+++ b/vendor.conf
@@ -1,7 +1,7 @@
 github.com/BurntSushi/toml v0.3.0
 github.com/containerd/cgroups 5e610833b72089b37d0e615de9a92dfc043757c2
 github.com/containerd/console c12b1e7919c14469339a5d38f2f8ed9b64a9de23
-github.com/containerd/containerd v1.2.0
+github.com/containerd/containerd v1.2.2
 github.com/containerd/cri 4dd6735020f5596dd41738f8c4f5cb07fa804c5e
 github.com/containerd/fifo 3d5202aec260678c48179c56f40e6f38a095738c
 github.com/containerd/go-runc 5a6d9f37cfa36b15efba46dc7ea349fa9b7143c3
@@ -13,7 +13,7 @@ github.com/godbus/dbus c7fdd8b5cd55e87b4e1f4e372cdb1db61dd6c66f
 github.com/gogo/protobuf v1.0.0
 github.com/golang/protobuf v1.1.0
 github.com/opencontainers/go-digest c9281466c8b2f606084ac71339773efd177436e7
-github.com/opencontainers/runc 58592df56734acf62e574865fe40b9e53e967910
+github.com/opencontainers/runc 96ec2177ae841256168fcf76954f7177af9446eb
 github.com/opencontainers/runtime-spec eba862dc2470385a233c7507392675cbeadf7353
 github.com/pkg/errors v0.8.0
 github.com/sirupsen/logrus v1.0.0

--- a/vendor/github.com/containerd/containerd/runtime/proc/proc.go
+++ b/vendor/github.com/containerd/containerd/runtime/proc/proc.go
@@ -40,7 +40,6 @@ func (s Stdio) IsNull() bool {
 
 // Process on a system
 type Process interface {
-	State
 	// ID returns the id for the process
 	ID() string
 	// Pid returns the pid for the process
@@ -57,10 +56,6 @@ type Process interface {
 	Status(context.Context) (string, error)
 	// Wait blocks until the process has exited
 	Wait()
-}
-
-// State of a process
-type State interface {
 	// Resize resizes the process console
 	Resize(ws console.WinSize) error
 	// Start execution of the process

--- a/vendor/github.com/containerd/containerd/runtime/v1/linux/proc/deleted_state.go
+++ b/vendor/github.com/containerd/containerd/runtime/v1/linux/proc/deleted_state.go
@@ -69,3 +69,7 @@ func (s *deletedState) SetExited(status int) {
 func (s *deletedState) Exec(ctx context.Context, path string, r *ExecConfig) (proc.Process, error) {
 	return nil, errors.Errorf("cannot exec in a deleted state")
 }
+
+func (s *deletedState) Pid() int {
+	return -1
+}

--- a/vendor/github.com/containerd/containerd/runtime/v1/linux/proc/exec.go
+++ b/vendor/github.com/containerd/containerd/runtime/v1/linux/proc/exec.go
@@ -41,7 +41,7 @@ import (
 type execProcess struct {
 	wg sync.WaitGroup
 
-	proc.State
+	execState execState
 
 	mu      sync.Mutex
 	id      string
@@ -69,8 +69,10 @@ func (e *execProcess) ID() string {
 }
 
 func (e *execProcess) Pid() int {
-	e.mu.Lock()
-	defer e.mu.Unlock()
+	return e.execState.Pid()
+}
+
+func (e *execProcess) pidv() int {
 	return e.pid
 }
 
@@ -86,11 +88,25 @@ func (e *execProcess) ExitedAt() time.Time {
 	return e.exited
 }
 
+func (e *execProcess) SetExited(status int) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.execState.SetExited(status)
+}
+
 func (e *execProcess) setExited(status int) {
 	e.status = status
 	e.exited = time.Now()
 	e.parent.Platform.ShutdownConsole(context.Background(), e.console)
 	close(e.waitBlock)
+}
+
+func (e *execProcess) Delete(ctx context.Context) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	return e.execState.Delete(ctx)
 }
 
 func (e *execProcess) delete(ctx context.Context) error {
@@ -107,11 +123,25 @@ func (e *execProcess) delete(ctx context.Context) error {
 	return nil
 }
 
+func (e *execProcess) Resize(ws console.WinSize) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	return e.execState.Resize(ws)
+}
+
 func (e *execProcess) resize(ws console.WinSize) error {
 	if e.console == nil {
 		return nil
 	}
 	return e.console.Resize(ws)
+}
+
+func (e *execProcess) Kill(ctx context.Context, sig uint32, _ bool) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	return e.execState.Kill(ctx, sig, false)
 }
 
 func (e *execProcess) kill(ctx context.Context, sig uint32, _ bool) error {
@@ -130,6 +160,13 @@ func (e *execProcess) Stdin() io.Closer {
 
 func (e *execProcess) Stdio() proc.Stdio {
 	return e.stdio
+}
+
+func (e *execProcess) Start(ctx context.Context) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	return e.execState.Start(ctx)
 }
 
 func (e *execProcess) start(ctx context.Context) (err error) {
@@ -172,22 +209,27 @@ func (e *execProcess) start(ctx context.Context) (err error) {
 		e.stdin = sc
 	}
 	var copyWaitGroup sync.WaitGroup
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	if socket != nil {
 		console, err := socket.ReceiveMaster()
 		if err != nil {
+			cancel()
 			return errors.Wrap(err, "failed to retrieve console master")
 		}
 		if e.console, err = e.parent.Platform.CopyConsole(ctx, console, e.stdio.Stdin, e.stdio.Stdout, e.stdio.Stderr, &e.wg, &copyWaitGroup); err != nil {
+			cancel()
 			return errors.Wrap(err, "failed to start console copy")
 		}
 	} else if !e.stdio.IsNull() {
 		if err := copyPipes(ctx, e.io, e.stdio.Stdin, e.stdio.Stdout, e.stdio.Stderr, &e.wg, &copyWaitGroup); err != nil {
+			cancel()
 			return errors.Wrap(err, "failed to start io pipe copy")
 		}
 	}
 	copyWaitGroup.Wait()
 	pid, err := runc.ReadPidFile(opts.PidFile)
 	if err != nil {
+		cancel()
 		return errors.Wrap(err, "failed to retrieve OCI runtime exec pid")
 	}
 	e.pid = pid

--- a/vendor/github.com/containerd/containerd/runtime/v1/linux/proc/exec_state.go
+++ b/vendor/github.com/containerd/containerd/runtime/v1/linux/proc/exec_state.go
@@ -25,6 +25,15 @@ import (
 	"github.com/pkg/errors"
 )
 
+type execState interface {
+	Resize(console.WinSize) error
+	Start(context.Context) error
+	Delete(context.Context) error
+	Kill(context.Context, uint32, bool) error
+	SetExited(int)
+	Pid() int
+}
+
 type execCreatedState struct {
 	p *execProcess
 }
@@ -32,11 +41,11 @@ type execCreatedState struct {
 func (s *execCreatedState) transition(name string) error {
 	switch name {
 	case "running":
-		s.p.State = &execRunningState{p: s.p}
+		s.p.execState = &execRunningState{p: s.p}
 	case "stopped":
-		s.p.State = &execStoppedState{p: s.p}
+		s.p.execState = &execStoppedState{p: s.p}
 	case "deleted":
-		s.p.State = &deletedState{}
+		s.p.execState = &deletedState{}
 	default:
 		return errors.Errorf("invalid state transition %q to %q", stateName(s), name)
 	}
@@ -44,15 +53,10 @@ func (s *execCreatedState) transition(name string) error {
 }
 
 func (s *execCreatedState) Resize(ws console.WinSize) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	return s.p.resize(ws)
 }
 
 func (s *execCreatedState) Start(ctx context.Context) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
 	if err := s.p.start(ctx); err != nil {
 		return err
 	}
@@ -63,27 +67,26 @@ func (s *execCreatedState) Delete(ctx context.Context) error {
 	if err := s.p.delete(ctx); err != nil {
 		return err
 	}
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
+
 	return s.transition("deleted")
 }
 
 func (s *execCreatedState) Kill(ctx context.Context, sig uint32, all bool) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	return s.p.kill(ctx, sig, all)
 }
 
 func (s *execCreatedState) SetExited(status int) {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	s.p.setExited(status)
 
 	if err := s.transition("stopped"); err != nil {
 		panic(err)
 	}
+}
+
+func (s *execCreatedState) Pid() int {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+	return s.p.pidv()
 }
 
 type execRunningState struct {
@@ -93,7 +96,7 @@ type execRunningState struct {
 func (s *execRunningState) transition(name string) error {
 	switch name {
 	case "stopped":
-		s.p.State = &execStoppedState{p: s.p}
+		s.p.execState = &execStoppedState{p: s.p}
 	default:
 		return errors.Errorf("invalid state transition %q to %q", stateName(s), name)
 	}
@@ -101,42 +104,33 @@ func (s *execRunningState) transition(name string) error {
 }
 
 func (s *execRunningState) Resize(ws console.WinSize) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	return s.p.resize(ws)
 }
 
 func (s *execRunningState) Start(ctx context.Context) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	return errors.Errorf("cannot start a running process")
 }
 
 func (s *execRunningState) Delete(ctx context.Context) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	return errors.Errorf("cannot delete a running process")
 }
 
 func (s *execRunningState) Kill(ctx context.Context, sig uint32, all bool) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	return s.p.kill(ctx, sig, all)
 }
 
 func (s *execRunningState) SetExited(status int) {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	s.p.setExited(status)
 
 	if err := s.transition("stopped"); err != nil {
 		panic(err)
 	}
+}
+
+func (s *execRunningState) Pid() int {
+	s.p.mu.Lock()
+	defer s.p.mu.Unlock()
+	return s.p.pidv()
 }
 
 type execStoppedState struct {
@@ -146,7 +140,7 @@ type execStoppedState struct {
 func (s *execStoppedState) transition(name string) error {
 	switch name {
 	case "deleted":
-		s.p.State = &deletedState{}
+		s.p.execState = &deletedState{}
 	default:
 		return errors.Errorf("invalid state transition %q to %q", stateName(s), name)
 	}
@@ -154,16 +148,10 @@ func (s *execStoppedState) transition(name string) error {
 }
 
 func (s *execStoppedState) Resize(ws console.WinSize) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	return errors.Errorf("cannot resize a stopped container")
 }
 
 func (s *execStoppedState) Start(ctx context.Context) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	return errors.Errorf("cannot start a stopped process")
 }
 
@@ -171,18 +159,18 @@ func (s *execStoppedState) Delete(ctx context.Context) error {
 	if err := s.p.delete(ctx); err != nil {
 		return err
 	}
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
+
 	return s.transition("deleted")
 }
 
 func (s *execStoppedState) Kill(ctx context.Context, sig uint32, all bool) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	return s.p.kill(ctx, sig, all)
 }
 
 func (s *execStoppedState) SetExited(status int) {
 	// no op
+}
+
+func (s *execStoppedState) Pid() int {
+	return s.p.pidv()
 }

--- a/vendor/github.com/containerd/containerd/runtime/v1/linux/proc/init.go
+++ b/vendor/github.com/containerd/containerd/runtime/v1/linux/proc/init.go
@@ -46,8 +46,8 @@ const InitPidFile = "init.pid"
 
 // Init represents an initial process for a container
 type Init struct {
-	wg sync.WaitGroup
-	initState
+	wg        sync.WaitGroup
+	initState initState
 
 	// mu is used to ensure that `Start()` and `Exited()` calls return in
 	// the right order when invoked in separate go routines.
@@ -168,18 +168,22 @@ func (p *Init) Create(ctx context.Context, r *CreateConfig) error {
 		p.closers = append(p.closers, sc)
 	}
 	var copyWaitGroup sync.WaitGroup
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	if socket != nil {
 		console, err := socket.ReceiveMaster()
 		if err != nil {
+			cancel()
 			return errors.Wrap(err, "failed to retrieve console master")
 		}
 		console, err = p.Platform.CopyConsole(ctx, console, r.Stdin, r.Stdout, r.Stderr, &p.wg, &copyWaitGroup)
 		if err != nil {
+			cancel()
 			return errors.Wrap(err, "failed to start console copy")
 		}
 		p.console = console
 	} else if !hasNoIO(r) {
 		if err := copyPipes(ctx, p.io, r.Stdin, r.Stdout, r.Stderr, &p.wg, &copyWaitGroup); err != nil {
+			cancel()
 			return errors.Wrap(err, "failed to start io pipe copy")
 		}
 	}
@@ -187,6 +191,7 @@ func (p *Init) Create(ctx context.Context, r *CreateConfig) error {
 	copyWaitGroup.Wait()
 	pid, err := runc.ReadPidFile(pidFile)
 	if err != nil {
+		cancel()
 		return errors.Wrap(err, "failed to retrieve OCI runtime container pid")
 	}
 	p.pid = pid
@@ -212,6 +217,7 @@ func (p *Init) Pid() int {
 func (p *Init) ExitStatus() int {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+
 	return p.status
 }
 
@@ -219,6 +225,7 @@ func (p *Init) ExitStatus() int {
 func (p *Init) ExitedAt() time.Time {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+
 	return p.exited
 }
 
@@ -226,6 +233,7 @@ func (p *Init) ExitedAt() time.Time {
 func (p *Init) Status(ctx context.Context) (string, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+
 	c, err := p.runtime.State(ctx, p.id)
 	if err != nil {
 		if strings.Contains(err.Error(), "does not exist") {
@@ -236,9 +244,25 @@ func (p *Init) Status(ctx context.Context) (string, error) {
 	return c.Status, nil
 }
 
-func (p *Init) start(context context.Context) error {
-	err := p.runtime.Start(context, p.id)
+// Start the init process
+func (p *Init) Start(ctx context.Context) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return p.initState.Start(ctx)
+}
+
+func (p *Init) start(ctx context.Context) error {
+	err := p.runtime.Start(ctx, p.id)
 	return p.runtimeError(err, "OCI runtime start failed")
+}
+
+// SetExited of the init process with the next status
+func (p *Init) SetExited(status int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.initState.SetExited(status)
 }
 
 func (p *Init) setExited(status int) {
@@ -248,9 +272,17 @@ func (p *Init) setExited(status int) {
 	close(p.waitBlock)
 }
 
-func (p *Init) delete(context context.Context) error {
+// Delete the init process
+func (p *Init) Delete(ctx context.Context) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return p.initState.Delete(ctx)
+}
+
+func (p *Init) delete(ctx context.Context) error {
 	p.wg.Wait()
-	err := p.runtime.Delete(context, p.id, nil)
+	err := p.runtime.Delete(ctx, p.id, nil)
 	// ignore errors if a runtime has already deleted the process
 	// but we still hold metadata and pipes
 	//
@@ -270,12 +302,23 @@ func (p *Init) delete(context context.Context) error {
 		p.io.Close()
 	}
 	if err2 := mount.UnmountAll(p.Rootfs, 0); err2 != nil {
-		log.G(context).WithError(err2).Warn("failed to cleanup rootfs mount")
+		log.G(ctx).WithError(err2).Warn("failed to cleanup rootfs mount")
 		if err == nil {
 			err = errors.Wrap(err2, "failed rootfs umount")
 		}
 	}
 	return err
+}
+
+// Resize the init processes console
+func (p *Init) Resize(ws console.WinSize) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.console == nil {
+		return nil
+	}
+	return p.console.Resize(ws)
 }
 
 func (p *Init) resize(ws console.WinSize) error {
@@ -285,26 +328,43 @@ func (p *Init) resize(ws console.WinSize) error {
 	return p.console.Resize(ws)
 }
 
-func (p *Init) pause(context context.Context) error {
-	err := p.runtime.Pause(context, p.id)
-	return p.runtimeError(err, "OCI runtime pause failed")
+// Pause the init process and all its child processes
+func (p *Init) Pause(ctx context.Context) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return p.initState.Pause(ctx)
 }
 
-func (p *Init) resume(context context.Context) error {
-	err := p.runtime.Resume(context, p.id)
-	return p.runtimeError(err, "OCI runtime resume failed")
+// Resume the init process and all its child processes
+func (p *Init) Resume(ctx context.Context) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return p.initState.Resume(ctx)
 }
 
-func (p *Init) kill(context context.Context, signal uint32, all bool) error {
-	err := p.runtime.Kill(context, p.id, int(signal), &runc.KillOpts{
+// Kill the init process
+func (p *Init) Kill(ctx context.Context, signal uint32, all bool) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return p.initState.Kill(ctx, signal, all)
+}
+
+func (p *Init) kill(ctx context.Context, signal uint32, all bool) error {
+	err := p.runtime.Kill(ctx, p.id, int(signal), &runc.KillOpts{
 		All: all,
 	})
 	return checkKillError(err)
 }
 
 // KillAll processes belonging to the init process
-func (p *Init) KillAll(context context.Context) error {
-	err := p.runtime.Kill(context, p.id, int(syscall.SIGKILL), &runc.KillOpts{
+func (p *Init) KillAll(ctx context.Context) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	err := p.runtime.Kill(ctx, p.id, int(syscall.SIGKILL), &runc.KillOpts{
 		All: true,
 	})
 	return p.runtimeError(err, "OCI runtime killall failed")
@@ -320,8 +380,16 @@ func (p *Init) Runtime() *runc.Runc {
 	return p.runtime
 }
 
+// Exec returns a new child process
+func (p *Init) Exec(ctx context.Context, path string, r *ExecConfig) (proc.Process, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return p.initState.Exec(ctx, path, r)
+}
+
 // exec returns a new exec'd process
-func (p *Init) exec(context context.Context, path string, r *ExecConfig) (proc.Process, error) {
+func (p *Init) exec(ctx context.Context, path string, r *ExecConfig) (proc.Process, error) {
 	// process exec request
 	var spec specs.Process
 	if err := json.Unmarshal(r.Spec.Value, &spec); err != nil {
@@ -342,18 +410,26 @@ func (p *Init) exec(context context.Context, path string, r *ExecConfig) (proc.P
 		},
 		waitBlock: make(chan struct{}),
 	}
-	e.State = &execCreatedState{p: e}
+	e.execState = &execCreatedState{p: e}
 	return e, nil
 }
 
-func (p *Init) checkpoint(context context.Context, r *CheckpointConfig) error {
+// Checkpoint the init process
+func (p *Init) Checkpoint(ctx context.Context, r *CheckpointConfig) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return p.initState.Checkpoint(ctx, r)
+}
+
+func (p *Init) checkpoint(ctx context.Context, r *CheckpointConfig) error {
 	var actions []runc.CheckpointAction
 	if !r.Exit {
 		actions = append(actions, runc.LeaveRunning)
 	}
 	work := filepath.Join(p.WorkDir, "criu-work")
 	defer os.RemoveAll(work)
-	if err := p.runtime.Checkpoint(context, p.id, &runc.CheckpointOpts{
+	if err := p.runtime.Checkpoint(ctx, p.id, &runc.CheckpointOpts{
 		WorkDir:                  work,
 		ImagePath:                r.Path,
 		AllowOpenTCP:             r.AllowOpenTCP,
@@ -364,19 +440,27 @@ func (p *Init) checkpoint(context context.Context, r *CheckpointConfig) error {
 	}, actions...); err != nil {
 		dumpLog := filepath.Join(p.Bundle, "criu-dump.log")
 		if cerr := copyFile(dumpLog, filepath.Join(work, "dump.log")); cerr != nil {
-			log.G(context).Error(err)
+			log.G(ctx).Error(err)
 		}
 		return fmt.Errorf("%s path= %s", criuError(err), dumpLog)
 	}
 	return nil
 }
 
-func (p *Init) update(context context.Context, r *google_protobuf.Any) error {
+// Update the processes resource configuration
+func (p *Init) Update(ctx context.Context, r *google_protobuf.Any) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return p.initState.Update(ctx, r)
+}
+
+func (p *Init) update(ctx context.Context, r *google_protobuf.Any) error {
 	var resources specs.LinuxResources
 	if err := json.Unmarshal(r.Value, &resources); err != nil {
 		return err
 	}
-	return p.runtime.Update(context, p.id, &resources)
+	return p.runtime.Update(ctx, p.id, &resources)
 }
 
 // Stdio of the process

--- a/vendor/github.com/containerd/containerd/runtime/v1/linux/proc/init_state.go
+++ b/vendor/github.com/containerd/containerd/runtime/v1/linux/proc/init_state.go
@@ -24,22 +24,25 @@ import (
 	"syscall"
 
 	"github.com/containerd/console"
-	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/runtime/proc"
 	"github.com/containerd/fifo"
 	runc "github.com/containerd/go-runc"
 	google_protobuf "github.com/gogo/protobuf/types"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 type initState interface {
-	proc.State
-
+	Resize(console.WinSize) error
+	Start(context.Context) error
+	Delete(context.Context) error
 	Pause(context.Context) error
 	Resume(context.Context) error
 	Update(context.Context, *google_protobuf.Any) error
 	Checkpoint(context.Context, *CheckpointConfig) error
 	Exec(context.Context, string, *ExecConfig) (proc.Process, error)
+	Kill(context.Context, uint32, bool) error
+	SetExited(int)
 }
 
 type createdState struct {
@@ -61,43 +64,26 @@ func (s *createdState) transition(name string) error {
 }
 
 func (s *createdState) Pause(ctx context.Context) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	return errors.Errorf("cannot pause task in created state")
 }
 
 func (s *createdState) Resume(ctx context.Context) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	return errors.Errorf("cannot resume task in created state")
 }
 
-func (s *createdState) Update(context context.Context, r *google_protobuf.Any) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
-	return s.p.update(context, r)
+func (s *createdState) Update(ctx context.Context, r *google_protobuf.Any) error {
+	return s.p.update(ctx, r)
 }
 
-func (s *createdState) Checkpoint(context context.Context, r *CheckpointConfig) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
+func (s *createdState) Checkpoint(ctx context.Context, r *CheckpointConfig) error {
 	return errors.Errorf("cannot checkpoint a task in created state")
 }
 
 func (s *createdState) Resize(ws console.WinSize) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	return s.p.resize(ws)
 }
 
 func (s *createdState) Start(ctx context.Context) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
 	if err := s.p.start(ctx); err != nil {
 		return err
 	}
@@ -105,8 +91,6 @@ func (s *createdState) Start(ctx context.Context) error {
 }
 
 func (s *createdState) Delete(ctx context.Context) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
 	if err := s.p.delete(ctx); err != nil {
 		return err
 	}
@@ -114,16 +98,10 @@ func (s *createdState) Delete(ctx context.Context) error {
 }
 
 func (s *createdState) Kill(ctx context.Context, sig uint32, all bool) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	return s.p.kill(ctx, sig, all)
 }
 
 func (s *createdState) SetExited(status int) {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	s.p.setExited(status)
 
 	if err := s.transition("stopped"); err != nil {
@@ -132,8 +110,6 @@ func (s *createdState) SetExited(status int) {
 }
 
 func (s *createdState) Exec(ctx context.Context, path string, r *ExecConfig) (proc.Process, error) {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
 	return s.p.exec(ctx, path, r)
 }
 
@@ -157,43 +133,26 @@ func (s *createdCheckpointState) transition(name string) error {
 }
 
 func (s *createdCheckpointState) Pause(ctx context.Context) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	return errors.Errorf("cannot pause task in created state")
 }
 
 func (s *createdCheckpointState) Resume(ctx context.Context) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	return errors.Errorf("cannot resume task in created state")
 }
 
-func (s *createdCheckpointState) Update(context context.Context, r *google_protobuf.Any) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
-	return s.p.update(context, r)
+func (s *createdCheckpointState) Update(ctx context.Context, r *google_protobuf.Any) error {
+	return s.p.update(ctx, r)
 }
 
-func (s *createdCheckpointState) Checkpoint(context context.Context, r *CheckpointConfig) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
+func (s *createdCheckpointState) Checkpoint(ctx context.Context, r *CheckpointConfig) error {
 	return errors.Errorf("cannot checkpoint a task in created state")
 }
 
 func (s *createdCheckpointState) Resize(ws console.WinSize) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	return s.p.resize(ws)
 }
 
 func (s *createdCheckpointState) Start(ctx context.Context) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
 	p := s.p
 	sio := p.stdio
 
@@ -247,8 +206,6 @@ func (s *createdCheckpointState) Start(ctx context.Context) error {
 }
 
 func (s *createdCheckpointState) Delete(ctx context.Context) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
 	if err := s.p.delete(ctx); err != nil {
 		return err
 	}
@@ -256,16 +213,10 @@ func (s *createdCheckpointState) Delete(ctx context.Context) error {
 }
 
 func (s *createdCheckpointState) Kill(ctx context.Context, sig uint32, all bool) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	return s.p.kill(ctx, sig, all)
 }
 
 func (s *createdCheckpointState) SetExited(status int) {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	s.p.setExited(status)
 
 	if err := s.transition("stopped"); err != nil {
@@ -274,9 +225,6 @@ func (s *createdCheckpointState) SetExited(status int) {
 }
 
 func (s *createdCheckpointState) Exec(ctx context.Context, path string, r *ExecConfig) (proc.Process, error) {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	return nil, errors.Errorf("cannot exec in a created state")
 }
 
@@ -297,67 +245,42 @@ func (s *runningState) transition(name string) error {
 }
 
 func (s *runningState) Pause(ctx context.Context) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-	if err := s.p.pause(ctx); err != nil {
-		return err
+	if err := s.p.runtime.Pause(ctx, s.p.id); err != nil {
+		return s.p.runtimeError(err, "OCI runtime pause failed")
 	}
+
 	return s.transition("paused")
 }
 
 func (s *runningState) Resume(ctx context.Context) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	return errors.Errorf("cannot resume a running process")
 }
 
-func (s *runningState) Update(context context.Context, r *google_protobuf.Any) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
-	return s.p.update(context, r)
+func (s *runningState) Update(ctx context.Context, r *google_protobuf.Any) error {
+	return s.p.update(ctx, r)
 }
 
 func (s *runningState) Checkpoint(ctx context.Context, r *CheckpointConfig) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	return s.p.checkpoint(ctx, r)
 }
 
 func (s *runningState) Resize(ws console.WinSize) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	return s.p.resize(ws)
 }
 
 func (s *runningState) Start(ctx context.Context) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	return errors.Errorf("cannot start a running process")
 }
 
 func (s *runningState) Delete(ctx context.Context) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	return errors.Errorf("cannot delete a running process")
 }
 
 func (s *runningState) Kill(ctx context.Context, sig uint32, all bool) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	return s.p.kill(ctx, sig, all)
 }
 
 func (s *runningState) SetExited(status int) {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	s.p.setExited(status)
 
 	if err := s.transition("stopped"); err != nil {
@@ -366,8 +289,6 @@ func (s *runningState) SetExited(status int) {
 }
 
 func (s *runningState) Exec(ctx context.Context, path string, r *ExecConfig) (proc.Process, error) {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
 	return s.p.exec(ctx, path, r)
 }
 
@@ -388,69 +309,47 @@ func (s *pausedState) transition(name string) error {
 }
 
 func (s *pausedState) Pause(ctx context.Context) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	return errors.Errorf("cannot pause a paused container")
 }
 
 func (s *pausedState) Resume(ctx context.Context) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
-	if err := s.p.resume(ctx); err != nil {
-		return err
+	if err := s.p.runtime.Resume(ctx, s.p.id); err != nil {
+		return s.p.runtimeError(err, "OCI runtime resume failed")
 	}
+
 	return s.transition("running")
 }
 
-func (s *pausedState) Update(context context.Context, r *google_protobuf.Any) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
-	return s.p.update(context, r)
+func (s *pausedState) Update(ctx context.Context, r *google_protobuf.Any) error {
+	return s.p.update(ctx, r)
 }
 
 func (s *pausedState) Checkpoint(ctx context.Context, r *CheckpointConfig) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	return s.p.checkpoint(ctx, r)
 }
 
 func (s *pausedState) Resize(ws console.WinSize) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	return s.p.resize(ws)
 }
 
 func (s *pausedState) Start(ctx context.Context) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	return errors.Errorf("cannot start a paused process")
 }
 
 func (s *pausedState) Delete(ctx context.Context) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	return errors.Errorf("cannot delete a paused process")
 }
 
 func (s *pausedState) Kill(ctx context.Context, sig uint32, all bool) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	return s.p.kill(ctx, sig, all)
 }
 
 func (s *pausedState) SetExited(status int) {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	s.p.setExited(status)
+
+	if err := s.p.runtime.Resume(context.Background(), s.p.id); err != nil {
+		logrus.WithError(err).Error("resuming exited container from paused state")
+	}
 
 	if err := s.transition("stopped"); err != nil {
 		panic(err)
@@ -458,9 +357,6 @@ func (s *pausedState) SetExited(status int) {
 }
 
 func (s *pausedState) Exec(ctx context.Context, path string, r *ExecConfig) (proc.Process, error) {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	return nil, errors.Errorf("cannot exec in a paused state")
 }
 
@@ -479,50 +375,30 @@ func (s *stoppedState) transition(name string) error {
 }
 
 func (s *stoppedState) Pause(ctx context.Context) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	return errors.Errorf("cannot pause a stopped container")
 }
 
 func (s *stoppedState) Resume(ctx context.Context) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	return errors.Errorf("cannot resume a stopped container")
 }
 
-func (s *stoppedState) Update(context context.Context, r *google_protobuf.Any) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
+func (s *stoppedState) Update(ctx context.Context, r *google_protobuf.Any) error {
 	return errors.Errorf("cannot update a stopped container")
 }
 
 func (s *stoppedState) Checkpoint(ctx context.Context, r *CheckpointConfig) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	return errors.Errorf("cannot checkpoint a stopped container")
 }
 
 func (s *stoppedState) Resize(ws console.WinSize) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	return errors.Errorf("cannot resize a stopped container")
 }
 
 func (s *stoppedState) Start(ctx context.Context) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	return errors.Errorf("cannot start a stopped process")
 }
 
 func (s *stoppedState) Delete(ctx context.Context) error {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
 	if err := s.p.delete(ctx); err != nil {
 		return err
 	}
@@ -530,7 +406,7 @@ func (s *stoppedState) Delete(ctx context.Context) error {
 }
 
 func (s *stoppedState) Kill(ctx context.Context, sig uint32, all bool) error {
-	return errdefs.ToGRPCf(errdefs.ErrNotFound, "process %s not found", s.p.id)
+	return s.p.kill(ctx, sig, all)
 }
 
 func (s *stoppedState) SetExited(status int) {
@@ -538,8 +414,5 @@ func (s *stoppedState) SetExited(status int) {
 }
 
 func (s *stoppedState) Exec(ctx context.Context, path string, r *ExecConfig) (proc.Process, error) {
-	s.p.mu.Lock()
-	defer s.p.mu.Unlock()
-
 	return nil, errors.Errorf("cannot exec in a stopped state")
 }

--- a/vendor/github.com/containerd/containerd/runtime/v1/linux/proc/utils.go
+++ b/vendor/github.com/containerd/containerd/runtime/v1/linux/proc/utils.go
@@ -93,7 +93,9 @@ func checkKillError(err error) error {
 	if err == nil {
 		return nil
 	}
-	if strings.Contains(err.Error(), "os: process already finished") || err == unix.ESRCH {
+	if strings.Contains(err.Error(), "os: process already finished") ||
+		strings.Contains(err.Error(), "container not running") ||
+		err == unix.ESRCH {
 		return errors.Wrapf(errdefs.ErrNotFound, "process already finished")
 	}
 	return errors.Wrapf(err, "unknown error after kill")

--- a/vendor/github.com/containerd/containerd/runtime/v1/shim/reaper.go
+++ b/vendor/github.com/containerd/containerd/runtime/v1/shim/reaper.go
@@ -31,7 +31,7 @@ import (
 // ErrNoSuchProcess is returned when the process no longer exists
 var ErrNoSuchProcess = errors.New("no such process")
 
-const bufferSize = 32
+const bufferSize = 2048
 
 // Reap should be called when the process receives an SIGCHLD.  Reap will reap
 // all exited processes and close their wait channels
@@ -47,7 +47,6 @@ func Reap() error {
 				Status:    e.Status,
 			}
 		}
-
 	}
 	Default.Unlock()
 	return err

--- a/vendor/github.com/containerd/containerd/runtime/v1/shim/service.go
+++ b/vendor/github.com/containerd/containerd/runtime/v1/shim/service.go
@@ -114,9 +114,6 @@ type Service struct {
 
 // Create a new initial process and container with the underlying OCI runtime
 func (s *Service) Create(ctx context.Context, r *shimapi.CreateTaskRequest) (_ *shimapi.CreateTaskResponse, err error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	var mounts []proc.Mount
 	for _, m := range r.Rootfs {
 		mounts = append(mounts, proc.Mount{
@@ -158,6 +155,10 @@ func (s *Service) Create(ctx context.Context, r *shimapi.CreateTaskRequest) (_ *
 			return nil, errors.Wrapf(err, "failed to mount rootfs component %v", m)
 		}
 	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	process, err := newInit(
 		ctx,
 		s.config.Path,
@@ -187,11 +188,9 @@ func (s *Service) Create(ctx context.Context, r *shimapi.CreateTaskRequest) (_ *
 
 // Start a process
 func (s *Service) Start(ctx context.Context, r *shimapi.StartRequest) (*shimapi.StartResponse, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	p := s.processes[r.ID]
-	if p == nil {
-		return nil, errdefs.ToGRPCf(errdefs.ErrNotFound, "process %s", r.ID)
+	p, err := s.getExecProcess(r.ID)
+	if err != nil {
+		return nil, err
 	}
 	if err := p.Start(ctx); err != nil {
 		return nil, err
@@ -204,16 +203,16 @@ func (s *Service) Start(ctx context.Context, r *shimapi.StartRequest) (*shimapi.
 
 // Delete the initial process and container
 func (s *Service) Delete(ctx context.Context, r *ptypes.Empty) (*shimapi.DeleteResponse, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	p := s.processes[s.id]
-	if p == nil {
-		return nil, errdefs.ToGRPCf(errdefs.ErrFailedPrecondition, "container must be created")
+	p, err := s.getInitProcess()
+	if err != nil {
+		return nil, err
 	}
 	if err := p.Delete(ctx); err != nil {
 		return nil, err
 	}
+	s.mu.Lock()
 	delete(s.processes, s.id)
+	s.mu.Unlock()
 	s.platform.Close()
 	return &shimapi.DeleteResponse{
 		ExitStatus: uint32(p.ExitStatus()),
@@ -227,11 +226,9 @@ func (s *Service) DeleteProcess(ctx context.Context, r *shimapi.DeleteProcessReq
 	if r.ID == s.id {
 		return nil, status.Errorf(codes.InvalidArgument, "cannot delete init process with DeleteProcess")
 	}
-	s.mu.Lock()
-	p := s.processes[r.ID]
-	s.mu.Unlock()
-	if p == nil {
-		return nil, errors.Wrapf(errdefs.ErrNotFound, "process %s", r.ID)
+	p, err := s.getExecProcess(r.ID)
+	if err != nil {
+		return nil, err
 	}
 	if err := p.Delete(ctx); err != nil {
 		return nil, err
@@ -249,13 +246,14 @@ func (s *Service) DeleteProcess(ctx context.Context, r *shimapi.DeleteProcessReq
 // Exec an additional process inside the container
 func (s *Service) Exec(ctx context.Context, r *shimapi.ExecProcessRequest) (*ptypes.Empty, error) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	if p := s.processes[r.ID]; p != nil {
+		s.mu.Unlock()
 		return nil, errdefs.ToGRPCf(errdefs.ErrAlreadyExists, "id %s", r.ID)
 	}
 
 	p := s.processes[s.id]
+	s.mu.Unlock()
 	if p == nil {
 		return nil, errdefs.ToGRPCf(errdefs.ErrFailedPrecondition, "container must be created")
 	}
@@ -271,14 +269,14 @@ func (s *Service) Exec(ctx context.Context, r *shimapi.ExecProcessRequest) (*pty
 	if err != nil {
 		return nil, errdefs.ToGRPC(err)
 	}
+	s.mu.Lock()
 	s.processes[r.ID] = process
+	s.mu.Unlock()
 	return empty, nil
 }
 
 // ResizePty of a process
 func (s *Service) ResizePty(ctx context.Context, r *shimapi.ResizePtyRequest) (*ptypes.Empty, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
 	if r.ID == "" {
 		return nil, errdefs.ToGRPCf(errdefs.ErrInvalidArgument, "id not provided")
 	}
@@ -286,7 +284,9 @@ func (s *Service) ResizePty(ctx context.Context, r *shimapi.ResizePtyRequest) (*
 		Width:  uint16(r.Width),
 		Height: uint16(r.Height),
 	}
+	s.mu.Lock()
 	p := s.processes[r.ID]
+	s.mu.Unlock()
 	if p == nil {
 		return nil, errors.Errorf("process does not exist %s", r.ID)
 	}
@@ -298,11 +298,9 @@ func (s *Service) ResizePty(ctx context.Context, r *shimapi.ResizePtyRequest) (*
 
 // State returns runtime state information for a process
 func (s *Service) State(ctx context.Context, r *shimapi.StateRequest) (*shimapi.StateResponse, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	p := s.processes[r.ID]
-	if p == nil {
-		return nil, errdefs.ToGRPCf(errdefs.ErrNotFound, "process id %s", r.ID)
+	p, err := s.getExecProcess(r.ID)
+	if err != nil {
+		return nil, err
 	}
 	st, err := p.Status(ctx)
 	if err != nil {
@@ -338,11 +336,9 @@ func (s *Service) State(ctx context.Context, r *shimapi.StateRequest) (*shimapi.
 
 // Pause the container
 func (s *Service) Pause(ctx context.Context, r *ptypes.Empty) (*ptypes.Empty, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	p := s.processes[s.id]
-	if p == nil {
-		return nil, errdefs.ToGRPCf(errdefs.ErrFailedPrecondition, "container must be created")
+	p, err := s.getInitProcess()
+	if err != nil {
+		return nil, err
 	}
 	if err := p.(*proc.Init).Pause(ctx); err != nil {
 		return nil, err
@@ -352,11 +348,9 @@ func (s *Service) Pause(ctx context.Context, r *ptypes.Empty) (*ptypes.Empty, er
 
 // Resume the container
 func (s *Service) Resume(ctx context.Context, r *ptypes.Empty) (*ptypes.Empty, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	p := s.processes[s.id]
-	if p == nil {
-		return nil, errdefs.ToGRPCf(errdefs.ErrFailedPrecondition, "container must be created")
+	p, err := s.getInitProcess()
+	if err != nil {
+		return nil, err
 	}
 	if err := p.(*proc.Init).Resume(ctx); err != nil {
 		return nil, err
@@ -366,12 +360,10 @@ func (s *Service) Resume(ctx context.Context, r *ptypes.Empty) (*ptypes.Empty, e
 
 // Kill a process with the provided signal
 func (s *Service) Kill(ctx context.Context, r *shimapi.KillRequest) (*ptypes.Empty, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
 	if r.ID == "" {
-		p := s.processes[s.id]
-		if p == nil {
-			return nil, errdefs.ToGRPCf(errdefs.ErrFailedPrecondition, "container must be created")
+		p, err := s.getInitProcess()
+		if err != nil {
+			return nil, err
 		}
 		if err := p.Kill(ctx, r.Signal, r.All); err != nil {
 			return nil, errdefs.ToGRPC(err)
@@ -379,9 +371,9 @@ func (s *Service) Kill(ctx context.Context, r *shimapi.KillRequest) (*ptypes.Emp
 		return empty, nil
 	}
 
-	p := s.processes[r.ID]
-	if p == nil {
-		return nil, errdefs.ToGRPCf(errdefs.ErrNotFound, "process id %s not found", r.ID)
+	p, err := s.getExecProcess(r.ID)
+	if err != nil {
+		return nil, err
 	}
 	if err := p.Kill(ctx, r.Signal, r.All); err != nil {
 		return nil, errdefs.ToGRPC(err)
@@ -422,11 +414,9 @@ func (s *Service) ListPids(ctx context.Context, r *shimapi.ListPidsRequest) (*sh
 
 // CloseIO of a process
 func (s *Service) CloseIO(ctx context.Context, r *shimapi.CloseIORequest) (*ptypes.Empty, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	p := s.processes[r.ID]
-	if p == nil {
-		return nil, errdefs.ToGRPCf(errdefs.ErrNotFound, "process does not exist %s", r.ID)
+	p, err := s.getExecProcess(r.ID)
+	if err != nil {
+		return nil, err
 	}
 	if stdin := p.Stdin(); stdin != nil {
 		if err := stdin.Close(); err != nil {
@@ -438,11 +428,9 @@ func (s *Service) CloseIO(ctx context.Context, r *shimapi.CloseIORequest) (*ptyp
 
 // Checkpoint the container
 func (s *Service) Checkpoint(ctx context.Context, r *shimapi.CheckpointTaskRequest) (*ptypes.Empty, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	p := s.processes[s.id]
-	if p == nil {
-		return nil, errdefs.ToGRPCf(errdefs.ErrFailedPrecondition, "container must be created")
+	p, err := s.getInitProcess()
+	if err != nil {
+		return nil, err
 	}
 	var options runctypes.CheckpointOptions
 	if r.Options != nil {
@@ -475,11 +463,9 @@ func (s *Service) ShimInfo(ctx context.Context, r *ptypes.Empty) (*shimapi.ShimI
 
 // Update a running container
 func (s *Service) Update(ctx context.Context, r *shimapi.UpdateTaskRequest) (*ptypes.Empty, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	p := s.processes[s.id]
-	if p == nil {
-		return nil, errdefs.ToGRPCf(errdefs.ErrFailedPrecondition, "container must be created")
+	p, err := s.getInitProcess()
+	if err != nil {
+		return nil, err
 	}
 	if err := p.(*proc.Init).Update(ctx, r.Resources); err != nil {
 		return nil, errdefs.ToGRPC(err)
@@ -489,11 +475,9 @@ func (s *Service) Update(ctx context.Context, r *shimapi.UpdateTaskRequest) (*pt
 
 // Wait for a process to exit
 func (s *Service) Wait(ctx context.Context, r *shimapi.WaitRequest) (*shimapi.WaitResponse, error) {
-	s.mu.Lock()
-	p := s.processes[r.ID]
-	s.mu.Unlock()
-	if p == nil {
-		return nil, errdefs.ToGRPCf(errdefs.ErrFailedPrecondition, "container must be created")
+	p, err := s.getExecProcess(r.ID)
+	if err != nil {
+		return nil, err
 	}
 	p.Wait()
 
@@ -509,16 +493,24 @@ func (s *Service) processExits() {
 	}
 }
 
-func (s *Service) checkProcesses(e runc.Exit) {
+func (s *Service) allProcesses() []rproc.Process {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	res := make([]rproc.Process, 0, len(s.processes))
+	for _, p := range s.processes {
+		res = append(res, p)
+	}
+	return res
+}
+
+func (s *Service) checkProcesses(e runc.Exit) {
 	shouldKillAll, err := shouldKillAllOnExit(s.bundle)
 	if err != nil {
 		log.G(s.context).WithError(err).Error("failed to check shouldKillAll")
 	}
 
-	for _, p := range s.processes {
+	for _, p := range s.allProcesses() {
 		if p.Pid() == e.Pid {
 
 			if shouldKillAll {
@@ -563,11 +555,9 @@ func shouldKillAllOnExit(bundlePath string) (bool, error) {
 }
 
 func (s *Service) getContainerPids(ctx context.Context, id string) ([]uint32, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	p := s.processes[s.id]
-	if p == nil {
-		return nil, errors.Wrapf(errdefs.ErrFailedPrecondition, "container must be created")
+	p, err := s.getInitProcess()
+	if err != nil {
+		return nil, err
 	}
 
 	ps, err := p.(*proc.Init).Runtime().Ps(ctx, id)
@@ -587,6 +577,30 @@ func (s *Service) forward(publisher events.Publisher) {
 			log.G(s.context).WithError(err).Error("post event")
 		}
 	}
+}
+
+// getInitProcess returns initial process
+func (s *Service) getInitProcess() (rproc.Process, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	p := s.processes[s.id]
+	if p == nil {
+		return nil, errdefs.ToGRPCf(errdefs.ErrFailedPrecondition, "container must be created")
+	}
+	return p, nil
+}
+
+// getExecProcess returns exec process
+func (s *Service) getExecProcess(id string) (rproc.Process, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	p := s.processes[id]
+	if p == nil {
+		return nil, errdefs.ToGRPCf(errdefs.ErrNotFound, "process %s does not exist", id)
+	}
+	return p, nil
 }
 
 func getTopic(ctx context.Context, e interface{}) string {

--- a/vendor/github.com/containerd/containerd/runtime/v1/shim/service_linux.go
+++ b/vendor/github.com/containerd/containerd/runtime/v1/shim/service_linux.go
@@ -49,9 +49,11 @@ func (p *linuxPlatform) CopyConsole(ctx context.Context, console console.Console
 		cwg.Add(1)
 		go func() {
 			cwg.Done()
-			p := bufPool.Get().(*[]byte)
-			defer bufPool.Put(p)
-			io.CopyBuffer(epollConsole, in, *p)
+			bp := bufPool.Get().(*[]byte)
+			defer bufPool.Put(bp)
+			io.CopyBuffer(epollConsole, in, *bp)
+			// we need to shutdown epollConsole when pipe broken
+			epollConsole.Shutdown(p.epoller.CloseConsole)
 		}()
 	}
 

--- a/vendor/github.com/containerd/containerd/runtime/v2/shim/reaper_unix.go
+++ b/vendor/github.com/containerd/containerd/runtime/v2/shim/reaper_unix.go
@@ -31,7 +31,7 @@ import (
 // ErrNoSuchProcess is returned when the process no longer exists
 var ErrNoSuchProcess = errors.New("no such process")
 
-const bufferSize = 32
+const bufferSize = 2048
 
 // Reap should be called when the process receives an SIGCHLD.  Reap will reap
 // all exited processes and close their wait channels
@@ -47,7 +47,6 @@ func Reap() error {
 				Status:    e.Status,
 			}
 		}
-
 	}
 	Default.Unlock()
 	return err

--- a/vendor/github.com/containerd/containerd/runtime/v2/shim/shim_unix.go
+++ b/vendor/github.com/containerd/containerd/runtime/v2/shim/shim_unix.go
@@ -87,7 +87,7 @@ func handleSignals(logger *logrus.Entry, signals chan os.Signal) error {
 }
 
 func openLog(ctx context.Context, _ string) (io.Writer, error) {
-	return fifo.OpenFifo(context.Background(), "log", unix.O_WRONLY, 0700)
+	return fifo.OpenFifo(ctx, "log", unix.O_WRONLY, 0700)
 }
 
 func (l *remoteEventsPublisher) Publish(ctx context.Context, topic string, event events.Event) error {

--- a/vendor/github.com/containerd/containerd/vendor.conf
+++ b/vendor/github.com/containerd/containerd/vendor.conf
@@ -20,7 +20,7 @@ github.com/gogo/protobuf v1.0.0
 github.com/gogo/googleapis 08a7655d27152912db7aaf4f983275eaf8d128ef
 github.com/golang/protobuf v1.1.0
 github.com/opencontainers/runtime-spec eba862dc2470385a233c7507392675cbeadf7353 # v1.0.1-45-geba862d
-github.com/opencontainers/runc 58592df56734acf62e574865fe40b9e53e967910
+github.com/opencontainers/runc 96ec2177ae841256168fcf76954f7177af9446eb
 github.com/sirupsen/logrus v1.0.0
 github.com/urfave/cli 7bc6a0acffa589f415f88aca16cc1de5ffd66f9c
 golang.org/x/net b3756b4b77d7b13260a0a2ec658753cf48922eac
@@ -33,7 +33,7 @@ golang.org/x/sync 450f422ab23cf9881c94e2db30cac0eb1b7cf80c
 github.com/BurntSushi/toml a368813c5e648fee92e5f6c30e3944ff9d5e8895
 github.com/grpc-ecosystem/go-grpc-prometheus 6b7015e65d366bf3f19b2b2a000a831940f0f7e0
 github.com/Microsoft/go-winio v0.4.11
-github.com/Microsoft/hcsshim v0.7.12
+github.com/Microsoft/hcsshim v0.8.1
 google.golang.org/genproto d80a6e20e776b0b17a324d0ba1ab50a39c8e8944
 golang.org/x/text 19e51611da83d6be54ddafce4a4af510cb3e9ea4
 github.com/containerd/ttrpc 2a805f71863501300ae1976d29f0454ae003e85a
@@ -43,7 +43,7 @@ github.com/google/go-cmp v0.1.0
 go.etcd.io/bbolt v1.3.1-etcd.8
 
 # cri dependencies
-github.com/containerd/cri f913714917d2456d7e65a0be84962b1ce8acb487 # release/1.2 branch
+github.com/containerd/cri 0d5cabd006cb5319dc965046067b8432d9fa5ef8 # release/1.2 branch
 github.com/containerd/go-cni 40bcf8ec8acd7372be1d77031d585d5d8e561c90
 github.com/blang/semver v3.1.0
 github.com/containernetworking/cni v0.6.0

--- a/vendor/github.com/opencontainers/runc/README.md
+++ b/vendor/github.com/opencontainers/runc/README.md
@@ -68,6 +68,7 @@ make BUILDTAGS='seccomp apparmor'
 | selinux   | selinux process and mount labeling | <none>      |
 | apparmor  | apparmor profile support           | <none>      |
 | ambient   | ambient capability support         | kernel 4.3  |
+| nokmem    | disable kernel memory account      | <none>      |
 
 
 ### Running the test suite
@@ -263,3 +264,7 @@ PIDFile=/run/mycontainerid.pid
 [Install]
 WantedBy=multi-user.target
 ```
+
+## License
+
+The code and docs are released under the [Apache 2.0 license](LICENSE).

--- a/vendor/github.com/opencontainers/runc/libcontainer/README.md
+++ b/vendor/github.com/opencontainers/runc/libcontainer/README.md
@@ -148,6 +148,7 @@ config := &configs.Config{
 		{Type: configs.NEWPID},
 		{Type: configs.NEWUSER},
 		{Type: configs.NEWNET},
+		{Type: configs.NEWCGROUP},
 	}),
 	Cgroups: &configs.Cgroup{
 		Name:   "test-container",
@@ -323,6 +324,7 @@ generated when building libcontainer with docker.
 
 ## Copyright and license
 
-Code and documentation copyright 2014 Docker, inc. Code released under the Apache 2.0 license.
-Docs released under Creative commons.
-
+Code and documentation copyright 2014 Docker, inc.
+The code and documentation are released under the [Apache 2.0 license](../LICENSE).
+The documentation is also released under Creative Commons Attribution 4.0 International License.
+You may obtain a copy of the license, titled CC-BY-4.0, at http://creativecommons.org/licenses/by/4.0/.


### PR DESCRIPTION
Based on https://github.com/google/gvisor-containerd-shim/pull/13.

This PR:
1) Update containerd to 1.2.2 to pick up fixes like https://github.com/containerd/containerd/pull/2762;
2) Port https://github.com/containerd/containerd/pull/2803. Actually this is not necessary, but it helps it easy to port future fixes.