### PR TITLE
Support task creation options passed by ContainerD 1.2.4

### DIFF
--- a/pkg/v2/service.go
+++ b/pkg/v2/service.go
@@ -240,6 +240,10 @@ func (s *service) Create(ctx context.Context, r *taskAPI.CreateTaskRequest) (_ *
 		}
 		var path string
 		switch o := v.(type) {
+		case *runctypes.CreateOptions: // containerd 1.2.x
+			opts.IoUid = o.IoUid
+			opts.IoGid = o.IoGid
+			opts.ShimCgroup = o.ShimCgroup
 		case *runctypes.RuncOptions: // containerd 1.2.x
 			root := proc.RunscRoot
 			if o.RuntimeRoot != "" {
@@ -262,7 +266,7 @@ func (s *service) Create(ctx context.Context, r *taskAPI.CreateTaskRequest) (_ *
 			}
 			path = o.ConfigPath
 		default:
-			return nil, errors.Errorf("unsupported option type")
+			return nil, errors.Errorf("unsupported option type %q", r.Options.TypeUrl)
 		}
 		if path != "" {
 			if _, err = toml.DecodeFile(path, &opts); err != nil {


### PR DESCRIPTION
When ContainerD v1.2.4 creates a task, it may pass a [`*runctypes.CreateOptions`](https://godoc.org/github.com/containerd/containerd/runtime/linux/runctypes#CreateOptions) in the request options field. This currently causes the gvisor-containerd-shim to reject the request.

This PR allows the shim to handle requests with creation options set, and also slightly improves the error message so future failures of this kind are easier to localize to the shim.

Fixes https://github.com/google/gvisor-containerd-shim/issues/19