### PR TITLE
fix: instructions to install shim

### DIFF
--- a/docs/runtime-handler-quickstart.md
+++ b/docs/runtime-handler-quickstart.md
@@ -19,20 +19,20 @@ later.
 [embedmd]:# (../test/e2e/shim-install.sh shell /{ # Step 1\(release\)/ /^}/)
 ```shell
 { # Step 1(release): Install gvisor-containerd-shim
-LATEST_RELEASE=$(wget -qO - https://api.github.com/repos/google/gvisor-containerd-shim/releases | grep -oP '(?<="browser_download_url": ")https://[^"]*' | head -1)
-wget -O gvisor-containerd-shim
+LATEST_RELEASE=$(wget -qO - https://api.github.com/repos/google/gvisor-containerd-shim/releases | grep -oP '(?<="browser_download_url": ")https://[^"]*gvisor-containerd-shim.linux-amd64' | head -1)
+wget -O gvisor-containerd-shim ${LATEST_RELEASE}
 chmod +x gvisor-containerd-shim
 sudo mv gvisor-containerd-shim /usr/local/bin/gvisor-containerd-shim
 }
 ```
 
 2. Create the configuration for the gvisor shim in
-   `/etc/containerd/gvisor-containerd-shim.yaml`:
+   `/etc/containerd/gvisor-containerd-shim.toml`:
 
 [embedmd]:# (../test/e2e/shim-install.sh shell /{ # Step 2/ /^}/)
 ```shell
-{ # Step 2: Create the gvisor-containerd-shim.yaml
-cat <<EOF | sudo tee /etc/containerd/gvisor-containerd-shim.yaml
+{ # Step 2: Create the gvisor-containerd-shim.toml
+cat <<EOF | sudo tee /etc/containerd/gvisor-containerd-shim.toml
 # This is the path to the default runc containerd-shim.
 runc_shim = "/usr/local/bin/containerd-shim"
 EOF

--- a/docs/untrusted-workload-quickstart.md
+++ b/docs/untrusted-workload-quickstart.md
@@ -22,20 +22,20 @@ are using containerd 1.2, please consider using runtime handler.*
 [embedmd]:# (../test/e2e/shim-install.sh shell /{ # Step 1/ /^}/)
 ```shell
 { # Step 1(release): Install gvisor-containerd-shim
-LATEST_RELEASE=$(wget -qO - https://api.github.com/repos/google/gvisor-containerd-shim/releases | grep -oP '(?<="browser_download_url": ")https://[^"]*' | head -1)
-wget -O gvisor-containerd-shim
+LATEST_RELEASE=$(wget -qO - https://api.github.com/repos/google/gvisor-containerd-shim/releases | grep -oP '(?<="browser_download_url": ")https://[^"]*gvisor-containerd-shim.linux-amd64' | head -1)
+wget -O gvisor-containerd-shim ${LATEST_RELEASE}
 chmod +x gvisor-containerd-shim
 sudo mv gvisor-containerd-shim /usr/local/bin/gvisor-containerd-shim
 }
 ```
 
 2. Create the configuration for the gvisor shim in
-   `/etc/containerd/gvisor-containerd-shim.yaml`:
+   `/etc/containerd/gvisor-containerd-shim.toml`:
 
 [embedmd]:# (../test/e2e/shim-install.sh shell /{ # Step 2/ /^}/)
 ```shell
-{ # Step 2: Create the gvisor-containerd-shim.yaml
-cat <<EOF | sudo tee /etc/containerd/gvisor-containerd-shim.yaml
+{ # Step 2: Create the gvisor-containerd-shim.toml
+cat <<EOF | sudo tee /etc/containerd/gvisor-containerd-shim.toml
 # This is the path to the default runc containerd-shim.
 runc_shim = "/usr/local/bin/containerd-shim"
 EOF

--- a/test/e2e/shim-install.sh
+++ b/test/e2e/shim-install.sh
@@ -7,8 +7,8 @@ set -ex
 # Build gvisor-containerd-shim
 if [ "${INSTALL_LATEST}" == "1" ]; then
 { # Step 1(release): Install gvisor-containerd-shim
-LATEST_RELEASE=$(wget -qO - https://api.github.com/repos/google/gvisor-containerd-shim/releases | grep -oP '(?<="browser_download_url": ")https://[^"]*' | head -1)
-wget -O gvisor-containerd-shim
+LATEST_RELEASE=$(wget -qO - https://api.github.com/repos/google/gvisor-containerd-shim/releases | grep -oP '(?<="browser_download_url": ")https://[^"]*gvisor-containerd-shim.linux-amd64' | head -1)
+wget -O gvisor-containerd-shim ${LATEST_RELEASE}
 chmod +x gvisor-containerd-shim
 sudo mv gvisor-containerd-shim /usr/local/bin/gvisor-containerd-shim
 }
@@ -19,8 +19,8 @@ else
 }
 fi
 
-{ # Step 2: Create the gvisor-containerd-shim.yaml
-cat <<EOF | sudo tee /etc/containerd/gvisor-containerd-shim.yaml
+{ # Step 2: Create the gvisor-containerd-shim.toml
+cat <<EOF | sudo tee /etc/containerd/gvisor-containerd-shim.toml
 # This is the path to the default runc containerd-shim.
 runc_shim = "/usr/local/bin/containerd-shim"
 EOF


### PR DESCRIPTION
1. original `LATEST_RELEASE` is about `containerd-shim-runsc-v1`, we should choose the second line `gvisor-containerd-shim`. lol

2. should use `/etc/containerd/gvisor-containerd-shim.toml`  not yaml : )

 fixes #18

Signed-off-by: zhuangqh <zhuangqhc@gmail.com>