### PR TITLE
fix: apply runtime path from runcOption to opts.BinaryName

### DIFF
--- a/pkg/v2/service.go
+++ b/pkg/v2/service.go
@@ -249,6 +249,9 @@ func (s *service) Create(ctx context.Context, r *taskAPI.CreateTaskRequest) (_ *
 			if o.RuntimeRoot != "" {
 				root = o.RuntimeRoot
 			}
+
+			opts.BinaryName = o.Runtime
+
 			path = filepath.Join(root, configFile)
 			if _, err := os.Stat(path); err != nil {
 				if !os.IsNotExist(err) {


### PR DESCRIPTION
enable to pass a custom runtime path to gvisor-containerd-shim

Signed-off-by: zhuangqh <zhuangqhc@gmail.com>