### PR TITLE
Updated e2e tests on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,15 @@
 dist: trusty
 sudo: required
 language: go
-go: "1.12.x"
+go: "1.14.x"
 
 env:
-  - GO111MODULE=on CONTAINERD_VERSION=1.1.5 RUNSC_VERSION=2019-08-06 TEST=untrusted-workload
-  - GO111MODULE=on CONTAINERD_VERSION=1.2.1 RUNSC_VERSION=2019-08-06 TEST=untrusted-workload
-  - GO111MODULE=on CONTAINERD_VERSION=1.2.1 RUNSC_VERSION=2019-08-06 TEST=runtime-handler
-  - GO111MODULE=on CONTAINERD_VERSION=1.2.1 RUNSC_VERSION=2019-08-06 TEST=runtime-handler-shim-v2
-
+  - CONTAINERD_VERSION=1.1.5 RUNSC_VERSION=release-20200219.0 TEST=untrusted-workload
+  - CONTAINERD_VERSION=1.2.13 RUNSC_VERSION=release-20200219.0 TEST=untrusted-workload
+  - CONTAINERD_VERSION=1.2.13 RUNSC_VERSION=release-20200219.0 TEST=runtime-handler
+  - CONTAINERD_VERSION=1.2.13 RUNSC_VERSION=release-20200219.0 TEST=runtime-handler-shim-v2
+  - CONTAINERD_VERSION=1.2.13 RUNSC_VERSION=release-20200219.0 TEST=runtime-handler-shim-v2
+  - CONTAINERD_VERSION=1.3.3 RUNSC_VERSION=release-20200219.0 TEST=runtime-handler-shim-v2
 
 go_import_path: github.com/google/gvisor-containerd-shim
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
-dist: trusty
+dist: bionic
 sudo: required
 language: go
 go: "1.14.x"
 
 env:
-  - CONTAINERD_VERSION=1.1.5 RUNSC_VERSION=release/20200219.0 TEST=untrusted-workload
+  - CONTAINERD_VERSION=1.1.8 RUNSC_VERSION=release/20200219.0 TEST=untrusted-workload
   - CONTAINERD_VERSION=1.2.13 RUNSC_VERSION=release/20200219.0 TEST=untrusted-workload
   - CONTAINERD_VERSION=1.2.13 RUNSC_VERSION=release/20200219.0 TEST=runtime-handler
   - CONTAINERD_VERSION=1.2.13 RUNSC_VERSION=release/20200219.0 TEST=runtime-handler-shim-v2
@@ -19,11 +19,10 @@ addons:
       - socat
       - conntrack
       - ipset
+      - libseccomp-dev
 
 before_install:
   - uname -r
-  - sudo apt-get -q update
-  - sudo apt-get install -y libseccomp-dev/trusty-backports
 
 script:
   - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,12 @@ language: go
 go: "1.14.x"
 
 env:
-  - CONTAINERD_VERSION=1.1.5 RUNSC_VERSION=release-20200219.0 TEST=untrusted-workload
-  - CONTAINERD_VERSION=1.2.13 RUNSC_VERSION=release-20200219.0 TEST=untrusted-workload
-  - CONTAINERD_VERSION=1.2.13 RUNSC_VERSION=release-20200219.0 TEST=runtime-handler
-  - CONTAINERD_VERSION=1.2.13 RUNSC_VERSION=release-20200219.0 TEST=runtime-handler-shim-v2
-  - CONTAINERD_VERSION=1.2.13 RUNSC_VERSION=release-20200219.0 TEST=runtime-handler-shim-v2
-  - CONTAINERD_VERSION=1.3.3 RUNSC_VERSION=release-20200219.0 TEST=runtime-handler-shim-v2
+  - CONTAINERD_VERSION=1.1.5 RUNSC_VERSION=release/20200219.0 TEST=untrusted-workload
+  - CONTAINERD_VERSION=1.2.13 RUNSC_VERSION=release/20200219.0 TEST=untrusted-workload
+  - CONTAINERD_VERSION=1.2.13 RUNSC_VERSION=release/20200219.0 TEST=runtime-handler
+  - CONTAINERD_VERSION=1.2.13 RUNSC_VERSION=release/20200219.0 TEST=runtime-handler-shim-v2
+  - CONTAINERD_VERSION=1.2.13 RUNSC_VERSION=release/20200219.0 TEST=runtime-handler-shim-v2
+  - CONTAINERD_VERSION=1.3.3 RUNSC_VERSION=release/20200219.0 TEST=runtime-handler-shim-v2
 
 go_import_path: github.com/google/gvisor-containerd-shim
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
   - CONTAINERD_VERSION=1.2.13 RUNSC_VERSION=release/20200219.0 TEST=untrusted-workload
   - CONTAINERD_VERSION=1.2.13 RUNSC_VERSION=release/20200219.0 TEST=runtime-handler
   - CONTAINERD_VERSION=1.2.13 RUNSC_VERSION=release/20200219.0 TEST=runtime-handler-shim-v2
-  - CONTAINERD_VERSION=1.2.13 RUNSC_VERSION=release/20200219.0 TEST=runtime-handler-shim-v2
+  - CONTAINERD_VERSION=1.3.3 RUNSC_VERSION=release/20200219.0 TEST=runtime-handler
   - CONTAINERD_VERSION=1.3.3 RUNSC_VERSION=release/20200219.0 TEST=runtime-handler-shim-v2
 
 go_import_path: github.com/google/gvisor-containerd-shim

--- a/test/e2e/containerd-install.sh
+++ b/test/e2e/containerd-install.sh
@@ -10,6 +10,13 @@ sudo mkdir -p /etc/containerd /etc/cni/net.d /opt/cni/bin
 sudo tar -xvf cni-plugins-amd64-v0.7.0.tgz -C /opt/cni/bin/
 sudo tar -xvf containerd-${CONTAINERD_VERSION}.linux-amd64.tar.gz -C /
 
+cat <<EOF | sudo tee /etc/containerd/config.toml
+disabled_plugins = ["restart"]
+# Set to avoid port overlap on older versions of containerd where default is 10010.
+[plugins.cri]
+  stream_server_port = "10011"
+EOF
+
 cat <<EOF | sudo tee /etc/cni/net.d/10-bridge.conf
 {
   "cniVersion": "0.3.1",
@@ -34,5 +41,4 @@ cat <<EOF | sudo tee /etc/cni/net.d/99-loopback.conf
 }
 EOF
 
-sudo PATH=$PATH containerd -log-level debug &> /tmp/containerd-cri.log &
-
+sudo PATH=$PATH containerd -log-level debug &>/tmp/containerd-cri.log &

--- a/test/e2e/runsc-install.sh
+++ b/test/e2e/runsc-install.sh
@@ -3,6 +3,6 @@
 # Sample script to install runsc
 
 wget -q --https-only \
-    https://storage.googleapis.com/gvisor/releases/nightly/${RUNSC_VERSION}/runsc
+    https://storage.googleapis.com/gvisor/releases/${RUNSC_VERSION}/runsc
 chmod +x runsc
 sudo mv runsc /usr/local/bin/

--- a/test/e2e/untrusted-workload/install.sh
+++ b/test/e2e/untrusted-workload/install.sh
@@ -11,6 +11,9 @@ disabled_plugins = ["restart"]
 [plugins.linux]
   shim = "/usr/local/bin/gvisor-containerd-shim"
   shim_debug = true
+# Set to avoid port overlap on older versions of containerd where default is 10010.
+[plugins.cri]
+  stream_server_port = "10011"
 [plugins.cri.containerd.untrusted_workload_runtime]
   runtime_type = "io.containerd.runtime.v1.linux"
   runtime_engine = "/usr/local/bin/runsc"
@@ -20,5 +23,5 @@ EOF
 
 { # Step 2: Restart containerd
 sudo pkill containerd
-sudo containerd -log-level debug &> /tmp/containerd-cri.log &
+sudo containerd -log-level debug &>/tmp/containerd-cri.log &
 }


### PR DESCRIPTION
- Updated tests to run using Go 1.14
- Added test for containerd 1.3
- Updated release of runsc to test